### PR TITLE
Fix for Multiorder Flattening in recycler.py

### DIFF
--- a/handlers/gwstreamer.py
+++ b/handlers/gwstreamer.py
@@ -145,12 +145,8 @@ class GWStreamer():
         --------
             flatten skymap.
         """
-
-        hdu = fits.open(input_skymap)
-        order = ah.nside_to_level(nside)
-        table = read_sky_map(hdu, moc=True)
-        table = rasterize(table, order=order)
-        write_sky_map(output_skymap, table, nest=True)
+		
+		os.system("ligo-skymap-flatten --nside {} {} {}".format(nside, input_skymap, output_skymap))
         
         return
     
@@ -187,8 +183,6 @@ class GWStreamer():
                                                       'combined_skymap.fits.gz')
         
         skymap.write(combined_skymap_output, overwrite=True)        
-        self.flatten_skymap(combined_skymap_output,
-                            combined_skymap_output_flatten)
         self.flatten_skymap(combined_skymap_output,
                             combined_skymap_output_flatten)
                     

--- a/recycler.py
+++ b/recycler.py
@@ -61,6 +61,12 @@ least_telescope = args.ltt
 
 with fits.open(skymap) as f:
     header = f[1].header
+	if header['ORDERING'] == 'NUNIQ':
+		skymap_flatten_path = skymap.replace(skymap.split('/')[-1], skymap.split('/')[-1].partition('.')[0] + "_flatten.fits.gz")
+		os.system('ligo-skymap-flatten --nside 1024 {} {}'.format(skymap, skymap_flatten_path))
+		with fits.open(skymap_flatten_path as f_flat:
+			header = f_flat[1].header
+		skymap = skymap_flatten_path 
 
 mjd = header['MJD-OBS']
 


### PR DESCRIPTION
Implemented `ligo-skymap-flatten` to flatten skymaps, as it is faster. Implemented a check in [recycler.py](https://github.com/SSantosLab/Main-Injector/blob/30e13e5a27b20469643ae32df61198ad0cd39a5c/recycler.py#L64) that flattens skymaps if they are multiorder (this happens if a test skymap is passed directly to `recycler.py` without `GWStreamer`).

Fix for #14.