### PR TITLE
Airmass edit

### DIFF
--- a/python/hex_object.py
+++ b/python/hex_object.py
@@ -129,8 +129,10 @@ class HexObject:
         
         airmass = self.getAirmass(mjd)
         
-        if airmass<=1.8: # Airmass of 1.8 is DECam limit
+        if airmass<=1.6 and airmass >= 1: # Airmass of 1.6 is where we wanted decline to become more steep
             return 2 - airmass
+        elif airmass <= 1.8: # Airmass of 1.8 is DECam limit
+            return 3.6 - 2*airmass
         elif airmass<1:
             return 1.
         else:


### PR DESCRIPTION
1. fixed the fact airmass factor can return a number greater than 1 since it didn't catch that it should be =1 anytime the airmass is 1 or less
2. updated it to more steeply decline between 1.6 and 1.8, hitting 0 at 1.8 (where it is unobservable) since 1.6 was where we decided it's barely worth observing anymore